### PR TITLE
build: compatibility for AGP 4.0

### DIFF
--- a/xnet/build.gradle
+++ b/xnet/build.gradle
@@ -1,18 +1,23 @@
+import org.gradle.util.VersionNumber
+
+def gradle6 = VersionNumber.parse(gradle.gradleVersion) >= VersionNumber.parse('6.0.0')
 apply plugin: 'com.android.library'
-apply plugin: 'com.novoda.bintray-release'
+if (!gradle6) {
+    apply plugin: 'com.novoda.bintray-release'
+}
 apply plugin: 'de.undercouch.download'
 
 boolean withNative = project.hasProperty("native") ? project.getProperty("native").toBoolean() : false
 String customNdkVersion = project.hasProperty("customNdkVersion") ? project.getProperty("customNdkVersion") : null
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     if (customNdkVersion != null) {
         ndkVersion customNdkVersion
     }
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 28
+        targetSdkVersion 29
 
         if (withNative) {
             externalNativeBuild {
@@ -92,14 +97,16 @@ if (withNative) {
     preBuild.dependsOn downloadAndUnzipFile
 }
 
-publish {
-    repoName = 'xnet-android-sdk'
-    userOrg = 'tencentyun'
-    groupId = 'com.tencent.qcloud'
-    artifactId = 'xnet'
-    publishVersion = '0.0.4'
-    desc = 'xnet android sdk'
-    website = 'https://github.com/tencentyun/xnet-android-sdk'
-}
+if (!gradle6) {
+    publish {
+        repoName = 'xnet-android-sdk'
+        userOrg = 'tencentyun'
+        groupId = 'com.tencent.qcloud'
+        artifactId = 'xnet'
+        publishVersion = '0.0.4'
+        desc = 'xnet android sdk'
+        website = 'https://github.com/tencentyun/xnet-android-sdk'
+    }
 
-bintrayUpload.dependsOn setHttpProxyFromEnv
+    bintrayUpload.dependsOn setHttpProxyFromEnv
+}


### PR DESCRIPTION
`bintray-release` don't support Gradle 6.x currently. see https://github.com/novoda/bintray-release/issues/298
disable the plugin when gradle version >=  6.
and upper sdk version to 29 for [AGP 4.0](https://developer.android.com/studio/releases/gradle-plugin#4-0-0)